### PR TITLE
Remove obsolete variables

### DIFF
--- a/README.org
+++ b/README.org
@@ -20,7 +20,7 @@ packages more convenient through emacs.
   
   The package attempts to guess which package manager you use.  If it
   guesses wrong (or you'd like to set it manually), you may modify the
-  variable =system-packages-packagemanager=.
+  variable =system-packages-package-manager=.
 
   We also attempt to guess whether or not to use sudo with appropriate
   commands (like installing and uninstalling packages). Some package
@@ -80,10 +80,10 @@ the commands to =system-packages-supported-package-managers= like so:
                          (noconfirm . "--noconfirm"))))
 #+END_SRC
 
-You may then need to adjust =system-packages-packagemanager= and
+You may then need to adjust =system-packages-package-manager= and
 =system-packages-usesudo= accordingly:
 
 #+BEGIN_SRC emacs-lisp
   (setq system-packages-usesudo t)
-  (setq system-packages-packagemanager "pacaur")
+  (setq system-packages-package-manager "pacaur")
 #+END_SRC

--- a/README.org
+++ b/README.org
@@ -26,7 +26,7 @@ packages more convenient through emacs.
   commands (like installing and uninstalling packages). Some package
   managers (like homebrew) warn not to use sudo, others (like =apt=)
   need sudo privileges. You may set this manually by configuring
-  =system-packages-usesudo=.
+  =system-packages-use-sudo=.
 
   Other package customization options can be accessed with M-x
   =customize-group RET system-packages RET=.
@@ -81,9 +81,9 @@ the commands to =system-packages-supported-package-managers= like so:
 #+END_SRC
 
 You may then need to adjust =system-packages-package-manager= and
-=system-packages-usesudo= accordingly:
+=system-packages-use-sudo= accordingly:
 
 #+BEGIN_SRC emacs-lisp
-  (setq system-packages-usesudo t)
+  (setq system-packages-use-sudo t)
   (setq system-packages-package-manager "pacaur")
 #+END_SRC

--- a/system-packages.el
+++ b/system-packages.el
@@ -256,7 +256,7 @@ default."
   'system-packages-package-manager "2017-12-25")
 
 (defcustom system-packages-use-sudo
-  (cdr (assoc 'default-sudo (cdr (assoc system-packages-packagemanager
+  (cdr (assoc 'default-sudo (cdr (assoc system-packages-package-manager
                                         system-packages-supported-package-managers))))
   "If non-nil, system-packages uses sudo for appropriate commands.
 
@@ -282,14 +282,14 @@ used to operation on specific packages.
 ARGS gets passed to the command and is useful for passing options
 to the package manager."
   (let ((command
-         (cdr (assoc action (cdr (assoc system-packages-packagemanager
+         (cdr (assoc action (cdr (assoc system-packages-package-manager
                                         system-packages-supported-package-managers)))))
         (noconfirm (when system-packages-noconfirm
                      (cdr (assoc 'noconfirm
-                                 (cdr (assoc system-packages-packagemanager
+                                 (cdr (assoc system-packages-package-manager
                                              system-packages-supported-package-managers)))))))
     (unless command
-      (error (format "%S not supported in %S" action system-packages-packagemanager)))
+      (error (format "%S not supported in %S" action system-packages-package-manager)))
     (unless (listp command)
       (setq command (list command)))
     (when system-packages-usesudo
@@ -309,7 +309,7 @@ to the package manager."
 (defun system-packages-install (pack &optional args)
   "Install system packages.
 
-Use the package manager from `system-packages-packagemanager' to
+Use the package manager from `system-packages-package-manager' to
 install PACK.  You may use ARGS to pass options to the package
 manger."
   (interactive "sPackage to install: ")
@@ -319,7 +319,7 @@ manger."
 (defun system-packages-search (pack &optional args)
   "Search for system packages.
 
-Use the package manager named in `system-packages-packagemanager'
+Use the package manager named in `system-packages-package-manager'
 to search for PACK.  You may use ARGS to pass options to the
 package manager."
   (interactive "sSearch string: ")
@@ -330,7 +330,7 @@ package manager."
   "Uninstall system packages.
 
 Uses the package manager named in
-`system-packages-packagemanager' to uninstall PACK.  You may use
+`system-packages-package-manager' to uninstall PACK.  You may use
 ARGS to pass options to the package manager."
   (interactive "sWhat package to uninstall: ")
   (system-packages--run-command 'uninstall pack args))
@@ -370,7 +370,7 @@ You may use ARGS to pass options to the package manager."
 (defun system-packages-update (&optional args)
   "Update system packages.
 
-Use the package manager `system-packages-packagemanager'.  You
+Use the package manager `system-packages-package-manager'.  You
 may use ARGS to pass options to the package manger."
   (interactive)
   (system-packages--run-command 'update nil args))
@@ -380,7 +380,7 @@ may use ARGS to pass options to the package manger."
   "Remove orphaned packages.
 
 Uses the package manager named in
-`system-packages-packagemanager'.  You may use ARGS to pass
+`system-packages-package-manager'.  You may use ARGS to pass
 options to the package manger."
   (interactive)
   (system-packages--run-command 'remove-orphaned nil args))
@@ -390,7 +390,7 @@ options to the package manger."
   "List explicitly installed packages.
 
 Uses the package manager named in
-`system-packages-packagemanager'.  With
+`system-packages-package-manager'.  With
 \\[universal-argument] (for ALL), list all installed packages.
 You may use ARGS to pass options to the package manger."
   (interactive "P")
@@ -408,7 +408,7 @@ You may use ARGS to pass options to the package manger."
 
 ;;;###autoload
 (defun system-packages-log (&optional args)
-  "Show a log from `system-packages-packagemanager'.
+  "Show a log from `system-packages-package-manager'.
 
 You may use ARGS to pass options to the package manger."
   (interactive)

--- a/system-packages.el
+++ b/system-packages.el
@@ -292,7 +292,7 @@ to the package manager."
       (error (format "%S not supported in %S" action system-packages-package-manager)))
     (unless (listp command)
       (setq command (list command)))
-    (when system-packages-usesudo
+    (when system-packages-use-sudo
       (setq command (mapcar (lambda (part) (concat "sudo " part)) command)))
     (setq command (mapconcat 'identity command " && "))
     (setq command (mapconcat 'identity (list command pack) " "))


### PR DESCRIPTION
The current code sets the variables `system-packages-packagemanager` and `system-packages-usesudo` as obsolete (see LOC https://github.com/jabranham/system-packages/blob/78fd4c0cf9ce9a5b824a01fd91429c94ea2b2920/system-packages.el#L255 and https://github.com/jabranham/system-packages/blob/78fd4c0cf9ce9a5b824a01fd91429c94ea2b2920/system-packages.el#L266). However, other parts of the code still use these variables, and the variables appear in the docs and in the README. This PR fixes all of that.