### PR TITLE
workaround: use C locale for sudo to ensure that the password prompt matcher works

### DIFF
--- a/system-packages.el
+++ b/system-packages.el
@@ -297,7 +297,7 @@ to the package manager."
     (unless (listp command)
       (setq command (list command)))
     (when system-packages-use-sudo
-      (setq command (mapcar (lambda (part) (concat "sudo " part)) command)))
+      (setq command (mapcar (lambda (part) (concat "LANG=C sudo " part)) command)))
     (setq command (mapconcat 'identity command " && "))
     (setq command (mapconcat 'identity (list command pack) " "))
     (setq args (concat args noconfirm))


### PR DESCRIPTION
This is a workaround for non-english locales (mine: german) to make comint-mode ask for my password. It should not be necessary, but it seems to be.