### PR TITLE
Fix missing space before a nonconfirm option

### DIFF
--- a/system-packages.el
+++ b/system-packages.el
@@ -328,9 +328,9 @@ of passing additional arguments to the package manager."
       (setq command (mapcar (lambda (part) (concat "sudo " part)) command)))
     (setq command (mapconcat 'identity command " && "))
     (setq command (mapconcat 'identity (list command pack) " "))
-    (setq args (concat args noconfirm))
-    (when args
-      (setq command (concat command args)))))
+    (when noconfirm
+      (setq args (concat args (and pack " ") noconfirm)))
+    (concat command args)))
 
 (defun system-packages--run-command (action &optional pack args)
   "Run a command asynchronously using the system's package manager.

--- a/test/system-packages-test.el
+++ b/test/system-packages-test.el
@@ -33,7 +33,13 @@
                  (system-packages-use-sudo t)
                  (system-packages-package-manager 'pacman))
              (system-packages-get-command 'install))
-           "sudo pacman -S --noconfirm")))
+           "sudo pacman -S --noconfirm"))
+  (should (string=
+           (let ((system-packages-noconfirm t)
+                 (system-packages-use-sudo t)
+                 (system-packages-package-manager 'apt))
+             (system-packages-get-command 'install "rg"))
+           "sudo apt-get install rg -y")))
 
 (ert-deftest system-packages-errors ()
   "Error when we don't know a command."


### PR DESCRIPTION
Currently `system-packages-get-command` does not put a space before a
nonconfirm option and it results in incorrect command, so instead of

```sh
sudo apt-get install rg -y
```

We receive

```sh
sudo apt-get install rg-y
```

This change adds an additional space before noconfirm option if `PACK`
parameter was provided.